### PR TITLE
introduce`complete_object` to handle structured output generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ bytes = "1.10.1"
 futures = "0.3.31"
 rand = "0.9.0"
 reqwest = { version = "0.12.12", features = ["json", "stream"] }
+schemars = "0.8.22"
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = "1.0.140"
 thiserror = "2.0.12"

--- a/examples/structured-generation/main.rs
+++ b/examples/structured-generation/main.rs
@@ -1,0 +1,105 @@
+use ai::{
+    model::{
+        ChatSettings,
+        chat::{ChatModel, Mode, OutputType, StructuredOutputParameters, StructuredResult},
+    },
+    provider::gemini::{GeminiProvider, GeminiSettings},
+};
+use dotenv::dotenv;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::env;
+
+// Define a struct for our structured output
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+struct Recipe {
+    name: String,
+    ingredients: Vec<String>,
+    instructions: Vec<String>,
+    prep_time_minutes: u32,
+    difficulty: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Load .env file if present
+    dotenv().ok();
+
+    // Get API key from environment
+    let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set");
+
+    // Create a Gemini provider with the default model (gemini-2.0-flash)
+    let provider = GeminiProvider::default(&api_key);
+
+    // Create Gemini-specific settings with structured outputs enabled
+    let gemini_settings = GeminiSettings::new()
+        .structured_outputs(true)
+        .into_provider_options();
+
+    // Create chat settings
+    let settings = ChatSettings::new()
+        .system_prompt("You are a helpful assistant specializing in creating recipes.")
+        .provider_options(gemini_settings);
+
+    // Create the chat model with the provider and settings
+    let model = ChatModel::new(provider, settings);
+
+    // Define the prompt for generating a structured recipe
+    let prompt =
+        "Create a recipe for a delicious vegetarian pasta dish that uses seasonal ingredients.";
+    println!("Sending prompt: {}", prompt);
+
+    // Set up parameters for structured output
+    let parameters = StructuredOutputParameters {
+        output: OutputType::Object,
+        mode: Some(Mode::Json),
+        schema: None::<Recipe>, // We're not providing an example, just the schema
+        schema_name: Some("Recipe".to_string()),
+        schema_description: Some("A cooking recipe with ingredients and instructions".to_string()),
+        enum_values: None,
+    };
+
+    // Generate the structured output
+    let response = model.generate_object(prompt, &parameters).await?;
+
+    // Print the response based on the structured result type
+    println!("\nAI Response (Structured Output):");
+    match &response.value {
+        StructuredResult::Object(recipe) => {
+            let recipe: &Recipe = recipe;
+            println!("Recipe: {}", recipe.name);
+            println!("\nDifficulty: {}", recipe.difficulty);
+            println!("Prep Time: {} minutes", recipe.prep_time_minutes);
+
+            println!("\nIngredients:");
+            for (i, ingredient) in recipe.ingredients.iter().enumerate() {
+                println!("  {}. {}", i + 1, ingredient);
+            }
+
+            println!("\nInstructions:");
+            for (i, step) in recipe.instructions.iter().enumerate() {
+                println!("  {}. {}", i + 1, step);
+            }
+        }
+        StructuredResult::Array(items) => {
+            println!("Received an array of {} recipes:", items.len());
+            // Handle array result if needed
+        }
+        StructuredResult::Enum(value) => {
+            println!("Received enum value: {}", value);
+        }
+        StructuredResult::NoSchema(value) => {
+            println!("Received unstructured data: {:#?}", value);
+        }
+    }
+
+    // Print usage statistics
+    println!("\nUsage Statistics:");
+    println!("  Prompt tokens: {}", response.usage.prompt_tokens);
+    println!("  Completion tokens: {}", response.usage.completion_tokens);
+    println!("  Total tokens: {}", response.usage.total_tokens);
+    println!("  Finish reason: {:?}", response.finish_reason);
+
+    Ok(())
+}
+

--- a/examples/structured-generation/main.rs
+++ b/examples/structured-generation/main.rs
@@ -1,7 +1,7 @@
 use ai::{
     model::{
         ChatSettings,
-        chat::{ChatModel, Mode, OutputType, StructuredOutputParameters, StructuredResult},
+        chat::{ChatModel, Mode, OutputType, Schema, StructuredOutputParameters, StructuredResult},
     },
     provider::gemini::{GeminiProvider, GeminiSettings},
 };
@@ -16,7 +16,7 @@ struct Recipe {
     name: String,
     ingredients: Vec<String>,
     instructions: Vec<String>,
-    prep_time_minutes: u32,
+    prep_time_minutes: i32,
     difficulty: String,
 }
 
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let parameters = StructuredOutputParameters {
         output: OutputType::Object,
         mode: Some(Mode::Json),
-        schema: None::<Recipe>, // We're not providing an example, just the schema
+        schema: Some(Schema::<Recipe>::new()),
         schema_name: Some("Recipe".to_string()),
         schema_description: Some("A cooking recipe with ingredients and instructions".to_string()),
         enum_values: None,
@@ -102,4 +102,3 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
-

--- a/src/model/chat.rs
+++ b/src/model/chat.rs
@@ -1,4 +1,5 @@
 use reqwest::header;
+use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::any::Any;
@@ -30,7 +31,7 @@ impl<P: Provider> ChatModel<P> {
         self.provider.stream_text(prompt, &self.settings).await
     }
 
-    pub async fn generate_object<T: DeserializeOwned>(
+    pub async fn generate_object<T: DeserializeOwned + JsonSchema + Sync>(
         &self,
         prompt: &str,
         parameters: &StructuredOutputParameters<T>,

--- a/src/model/chat.rs
+++ b/src/model/chat.rs
@@ -78,12 +78,14 @@ pub struct StructuredOutputParameters<T: DeserializeOwned> {
     pub enum_values: Option<Vec<String>>,
 }
 
+#[derive(Debug)]
 pub struct StructuredOutput<T: DeserializeOwned> {
     pub value: StructuredResult<T>,
     pub finish_reason: FinishReason,
     pub usage: LanguageModelUsage,
 }
 
+#[derive(Debug)]
 pub enum StructuredResult<T> {
     Object(T),
     Array(Vec<T>),

--- a/src/model/chat.rs
+++ b/src/model/chat.rs
@@ -4,6 +4,7 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::any::Any;
 use std::fmt::Debug;
+use std::marker::PhantomData;
 
 use crate::AIError;
 use crate::provider::Provider;
@@ -70,10 +71,25 @@ pub struct ChatSettings {
 }
 
 #[derive(Debug, Clone)]
+pub struct Schema<T: DeserializeOwned>(PhantomData<T>);
+
+impl<T: DeserializeOwned> Schema<T> {
+    pub fn new() -> Self {
+        Schema(PhantomData)
+    }
+}
+
+impl<T: DeserializeOwned> Default for Schema<T> {
+    fn default() -> Self {
+        Schema(PhantomData)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct StructuredOutputParameters<T: DeserializeOwned> {
     pub output: OutputType,
     pub mode: Option<Mode>,
-    pub schema: Option<T>,
+    pub schema: Option<Schema<T>>,
     pub schema_name: Option<String>,
     pub schema_description: Option<String>,
     pub enum_values: Option<Vec<String>>,

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,10 +1,11 @@
 pub mod gemini;
 
 use crate::error::AIError;
-use crate::model::chat::TextStream;
+use crate::model::chat::{StructuredOutput, StructuredOutputParameters, TextStream};
 use crate::model::{ChatSettings, TextCompletion};
 use async_trait::async_trait;
 use futures::Stream;
+use serde::de::DeserializeOwned;
 
 #[async_trait]
 pub trait Provider {
@@ -19,4 +20,11 @@ pub trait Provider {
         prompt: &'a str,
         settings: &'a ChatSettings,
     ) -> Result<impl Stream<Item = Result<TextStream, AIError>> + 'a, AIError>;
+
+    async fn generate_object<T: DeserializeOwned>(
+        &self,
+        prompt: &str,
+        settings: &ChatSettings,
+        parameters: &StructuredOutputParameters<T>,
+    ) -> Result<StructuredOutput<T>, AIError>;
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -5,6 +5,7 @@ use crate::model::chat::{StructuredOutput, StructuredOutputParameters, TextStrea
 use crate::model::{ChatSettings, TextCompletion};
 use async_trait::async_trait;
 use futures::Stream;
+use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
 #[async_trait]
@@ -21,7 +22,7 @@ pub trait Provider {
         settings: &'a ChatSettings,
     ) -> Result<impl Stream<Item = Result<TextStream, AIError>> + 'a, AIError>;
 
-    async fn generate_object<T: DeserializeOwned>(
+    async fn generate_object<T: DeserializeOwned + JsonSchema + Sync>(
         &self,
         prompt: &str,
         settings: &ChatSettings,

--- a/src/provider/gemini.rs
+++ b/src/provider/gemini.rs
@@ -664,8 +664,13 @@ fn to_provider_mime_type<T: DeserializeOwned>(
     params: &StructuredOutputParameters<T>,
 ) -> Option<MimeType> {
     match params.output {
-        chat::OutputType::Object => Some(MimeType::Json),
-        chat::OutputType::Array => Some(MimeType::Json),
+        chat::OutputType::Object | chat::OutputType::Array => {
+            if params.schema.is_some() {
+                Some(MimeType::Json)
+            } else {
+                None
+            }
+        }
         chat::OutputType::Enum => Some(MimeType::Enum),
         chat::OutputType::NoSchema => None,
     }
@@ -675,10 +680,13 @@ fn to_provider_response_schema<T: DeserializeOwned + JsonSchema>(
     params: &StructuredOutputParameters<T>,
 ) -> Option<SchemaObject> {
     match params.output {
-        chat::OutputType::Object | chat::OutputType::Array => params
-            .schema
-            .as_ref()
-            .map(|_| schemars::schema_for!(T).schema),
+        chat::OutputType::Object | chat::OutputType::Array => {
+            // Only generate schema if a schema instance is provided
+            params
+                .schema
+                .as_ref()
+                .map(|_| schemars::schema_for!(T).schema)
+        }
         _ => None,
     }
 }


### PR DESCRIPTION
the goal of this PR is to enable the following API

```rust
#[derive(Deserialize, Debug)]
struct Recipe {
    name: String,
    ingredients: Vec<String>,
    steps: Vec<String>,
}

let settings = GenerateObjectSettings {
    output: OutputType::Object,
    mode: Some(Mode::Auto),
    schema: Some(Recipe {
        name: String::new(),
        ingredients: Vec::new(),
        steps: Vec::new(),
    }),
    schema_name: Some("Recipe".to_string()),
    schema_description: Some("A cooking recipe".to_string()),
    enum_values: None,
};

let result = model.generate_object("Generate a lasagna recipe.", settings).await?;
if let GenerateObjectResult::Object(recipe) = result {
    println!("{:#?}", recipe);
}
```